### PR TITLE
Add VEML6070 UV Sensor library to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "libraries/helpers/dotstar_featherwing"]
 	path = libraries/helpers/dotstar_featherwing
 	url = https://github.com/dastels/circuitPython_dotstar_featherwing.git
+[submodule "libraries/drivers/veml6070"]
+	path = libraries/drivers/veml6070
+	url = https://github.com/sommersoft/veml6070.git


### PR DESCRIPTION
Added a VEML6070 UV sensor library.

[Adafruit VEML6070 UV Sensor Breakout](https://www.adafruit.com/products/2899) (Product ID: 2899)