### PR TITLE
Add nonblocking_timer library to community bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libraries/helpers/dotstar_featherwing"]
 	path = libraries/helpers/dotstar_featherwing
 	url = https://github.com/dastels/circuitPython_dotstar_featherwing.git
+[submodule "libraries/helpers/nonblocking_timer"]
+	path = libraries/helpers/nonblocking_timer
+	url = https://github.com/Angeleno-Tech/nonblocking_timer.git


### PR DESCRIPTION
Simplifies the use of time.monotonic()