### PR TITLE
Added slight_TLC5957 library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "libraries/drivers/sh1106"]
 	path = libraries/drivers/sh1106
 	url = https://github.com/winneymj/CircuitPython_SH1106
+[submodule "libraries/drivers/slight_tlc5957"]
+	path = libraries/drivers/slight_tlc5957
+	url = https://github.com/s-light/slight_CircuitPython_TLC5957.git


### PR DESCRIPTION
TODO: define naming convention for example files

in my library there are some examples and development helpers that are 
not starting with the library name -
in the community_bundle build all examples are thrown together in one example folder for all libraries - 
is this a good idea??
if every library has a `simple_example.py` that does not work...

please let me know what you think of this. 
for me iam fine with renaming my examples so they all start with the library name.