### PR TITLE
Add serlcd to CircuitPython Community Bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "libraries/drivers/ili9163"]
 	path = libraries/drivers/ili9163
 	url = https://github.com/electronut/Electronutlabs_CircuitPython_ILI9163
+[submodule "libraries/drivers/serlcd"]
+	path = libraries/drivers/serlcd
+	url = https://github.com/fourstix/Sparkfun_CircuitPython_SerLCD.git


### PR DESCRIPTION
Hello,
I have written a CircuitPython library for the Sparkfun SerLCD AVR-Based Serial LCD displays that I would like to share with the community. Please let me know if you need any information or if there is anything else you'd like me to do.

Have a great day,
Gaston aka fourstix