### PR TITLE
Adding an IFTTT wrapper library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,6 +52,3 @@
 [submodule "libraries/drivers/serlcd"]
 	path = libraries/drivers/serlcd
 	url = https://github.com/fourstix/Sparkfun_CircuitPython_SerLCD.git
-[submodule "libraries/helpers/ifttt"]
-	path = libraries/helpers/ifttt
-	url = https://github.com/benevpi/CIRCUITPYTHON_ifttt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "libraries/drivers/serlcd"]
 	path = libraries/drivers/serlcd
 	url = https://github.com/fourstix/Sparkfun_CircuitPython_SerLCD.git
+[submodule "libraries/helpers/ifttt"]
+	path = libraries/helpers/ifttt
+	url = https://github.com/benevpi/CIRCUITPYTHON_ifttt.git


### PR DESCRIPTION
Adding a wrapper library for IFTTTT (ifttt.com) to let you create events using webhooks from web-connected CircuitPython devices. It doesn't do a  *huge* amount, so if it's preferable not to have a library for this, ignore it.