### PR TITLE
adding nrf24l01 driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "libraries/helpers/ifttt"]
 	path = libraries/helpers/ifttt
 	url = https://github.com/benevpi/CIRCUITPYTHON_ifttt.git
+[submodule "libraries/drivers/nrf24l01"]
+	path = libraries/drivers/nrf24l01
+	url = https://github.com/2bndy5/CircuitPython_nRF24L01.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   on:
     tags: true
 
-script: circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 3
+script: circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   on:
     tags: true
 
-script: circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 2 
+script: circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 3


### PR DESCRIPTION
finally got around to doing this PR. The last page in the [sharing in a bundle](https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-in-the-community-bundle) walkthrough had something about modifying a docs/drivers.rst, but I couldn't locate the file (outdated info?).

let me know if there are some changes that still need to be made. IDK if [the other repo](https://github.com/adafruit/2bndy5_CircuitPython_NRF24L01) is still necessary