### PR TITLE
Add mitutoyo: A Mitutoyo Digimatic library.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,3 +61,6 @@
 [submodule "libraries/drivers/i2cencoderlibv21"]
 	path = libraries/drivers/i2cencoderlibv21
 	url = https://github.com/bwshockley/CircuitPython-i2cEncoderLibV21.git
+[submodule "libraries/drivers/mitutoyo"]
+	path = libraries/drivers/mitutoyo
+	url = https://github.com/vifino/CircuitPython-mitutoyo.git


### PR DESCRIPTION
By request of @ladyada in vifino/CircuitPython-mitutoyo#1, I added my small library to this bundle.
Should be pretty much feature complete and handy for those who have Mitutoyo Digimatic (SPC) capable Calipers or Micrometers. Apparently iGaging and some other manufacturers also produce instruments outputting the same data.