### PR TITLE
Add Pimoroni LTR559 driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "libraries/helpers/gamblor21_ahrs"]
 	path = libraries/helpers/gamblor21_ahrs
 	url = https://github.com/gamblor21/Gamblor21_CircuitPython_AHRS.git
+[submodule "libraries/drivers/ltr559"]
+	path = libraries/drivers/ltr559
+	url = https://github.com/pimoroni/Pimoroni_CircuitPython_LTR559/


### PR DESCRIPTION
It's my first shot at this- so hopefully the target library is prepared and submodule'd correctly. I've pushed a v0.0.1 release that should be functional and verified that the Release action produces .mpy files for published releases.

Cheers!