### PR TITLE
Fix Malformed URL To LTR559 Repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,4 +81,4 @@
 	url = https://github.com/gamblor21/Gamblor21_CircuitPython_AHRS.git
 [submodule "libraries/drivers/ltr559"]
 	path = libraries/drivers/ltr559
-	url = https://github.com/pimoroni/Pimoroni_CircuitPython_LTR559/
+	url = https://github.com/pimoroni/Pimoroni_CircuitPython_LTR559.git


### PR DESCRIPTION
Found this while looking into https://github.com/adafruit/adabot/issues/181.