### PR TITLE
Add jepler_udecimal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "libraries/drivers/ltr559"]
 	path = libraries/drivers/ltr559
 	url = https://github.com/pimoroni/Pimoroni_CircuitPython_LTR559.git
+[submodule "libraries/helpers/udecimal"]
+	path = libraries/helpers/udecimal
+	url = https://github.com/jepler/Jepler_CircuitPython_udecimal.git


### PR DESCRIPTION
`jepler_udecimal` is a reduced version of desktop Python's `decimal` library for CircuitPython, which allows for arbitrary precision decimal arithmetic.  It has been enhanced with arbitrary precision trig routines (sin/cos/tan and inverses).

It requires CircuitPython 6 and a fairly powerful microcontroller (I'm using it on nRF52840), due to the size of the mpy file.