### PR TITLE
Adding circuitpython_display_frame library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,3 +94,6 @@
 [submodule "libraries/drivers/mics6814"]
 	path = libraries/drivers/mics6814
 	url = https://github.com/pimoroni/Pimoroni_CircuitPython_MICS6814.git
+[submodule "libraries/helpers/circuitpython_display_frame"]
+	path = libraries/helpers/circuitpython_display_frame
+	url = https://github.com/FoamyGuy/CircuitPython_Display_Frame.git


### PR DESCRIPTION
This library is a re-usable displayio widget for making a rounded rectangle frame with text label at the top center of it.