### PR TITLE
adding at42qt1070 driver to community bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "libraries/helpers/discordbot"]
 	path = libraries/helpers/discordbot
 	url = https://github.com/2231puppy/CircuitPython_DiscordBot.git
+[submodule "libraries/drivers/at42qt107"]
+	path = libraries/drivers/at42qt107
+	url = https://github.com/skerr92/at42qt-acorn-python.git


### PR DESCRIPTION
Adding the driver I developed for the AT42QT1070 capacitive touch sensor. This works over i2c. Current driver works great (much thanks to the community) with future features on the docket for more diverse functionality.