### PR TITLE
add Cirque_Pinnacle lib to WIP list

### DIFF
--- a/works_in_progress.md
+++ b/works_in_progress.md
@@ -22,3 +22,4 @@ help get the driver ready for the Bundle.
 * [https://github.com/maholli/CircuitPython_INA226](https://github.com/maholli/CircuitPython_INA226)
 * [https://github.com/maholli/CircuitPython_BQ25883](https://github.com/maholli/CircuitPython_BQ25883)
 * [https://github.com/spacecraft-design-lab-2019/CircuitPython_BMX160](https://github.com/spacecraft-design-lab-2019/CircuitPython_BMX160)
+* [https://github.com/2bndy5/CircuitPython_Cirque_Pinnacle](https://github.com/2bndy5/CircuitPython_Cirque_Pinnacle)


### PR DESCRIPTION
I've made a library that allows using Cirque's Glidepoint circular trackpads (as found in the Steam Controller and HTC/Valve Vive VR controllers).

The SPI interface works fine, but I'm having trouble verifying that the I2C interface works (requires de-soldiering a resistor from the back of the trackpad). These trackpads are available on mouser.com (store link in the doc's navbar), but require a FFC/FPC connection (or a customized "bed of nails"). Additionally, development has slowed because proper testing requires a calibration to environmental capacitance (trackpad needs to be installed to a physical prototype housing), and my 3d drawing skills are sorely underdeveloped.