### PR TITLE
Added Franklin AS3935 driver library.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -103,3 +103,6 @@
 [submodule "libraries/drivers/wiichuck"]
 	path = libraries/drivers/wiichuck
 	url = https://github.com/jfurcean/CircuitPython_WiiChuck.git
+[submodule "libraries/drivers/as3935"]
+	path = libraries/drivers/as3935
+	url = https://github.com/BiffoBear/CircuitPython_AS3935.git


### PR DESCRIPTION
Added a driver for the Franklin AS3935 driver library. Followed the instructions in the Adafruit learning guide but the part about editing the link for the documents seems to be out of date, so I ignored it and pushed the reposititory.