### PR TITLE
Add CircuitPython_bteve as bteve

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -108,4 +108,4 @@
 	url = https://github.com/BiffoBear/CircuitPython_AS3935.git
 [submodule "libraries/drivers/bteve"]
 	path = libraries/drivers/bteve
-	url = git@github.com:jamesbowman/CircuitPython_bteve.git
+	url = https://github.com/jamesbowman/CircuitPython_bteve.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -106,3 +106,6 @@
 [submodule "libraries/drivers/as3935"]
 	path = libraries/drivers/as3935
 	url = https://github.com/BiffoBear/CircuitPython_AS3935.git
+[submodule "libraries/drivers/bteve"]
+	path = libraries/drivers/bteve
+	url = git@github.com:jamesbowman/CircuitPython_bteve.git


### PR DESCRIPTION
This adds the rest of the EVE support stack.