### PR TITLE
Add GC9A01 TFT-LCD displayio driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -109,3 +109,6 @@
 [submodule "libraries/drivers/bteve"]
 	path = libraries/drivers/bteve
 	url = https://github.com/jamesbowman/CircuitPython_bteve.git
+[submodule "libraries/drivers/gc9a01"]
+	path = libraries/drivers/gc9a01
+	url = https://github.com/tylercrumpton/CircuitPython_GC9A01.git


### PR DESCRIPTION
This PR adds a displayio driver library for GC9A01 THT-LCD displays to the community bundle. I think I got all of the pieces put together, but please let me know if there is something that needs to change or be added!