### PR TITLE
Added uschedule library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -115,3 +115,6 @@
 [submodule "libraries/helpers/PiperBlocklyLibrary"]
 	path = libraries/helpers/PiperBlocklyLibrary
 	url = https://github.com/buildwithpiper/PiperBlocklyLibrary.git
+[submodule "libraries/helpers/uschedule"]
+	path = libraries/helpers/uschedule
+	url = https://github.com/cognitivegears/CircuitPython_uschedule.git


### PR DESCRIPTION
Adding the CircuitPython_uschedule (https://github.com/cognitivegears/CircuitPython_uschedule) library, which is a version of schedule (https://pypi.org/project/schedule/) updated to work with CircuitPython.  This library allows for the scheduling of functions in a flexible functional style. This is useful to avoid having to hand-code scheduling into a circuitpython project, especially in conjunction with RTCs and long-scheduled jobs.  More information is available in the repo and readthedocs (https://circuitpython-uschedule.readthedocs.io).