### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CircuitPython Community Library Bundle
 
-[![Doc Status](https://readthedocs.org/projects/circuitpython/badge/?version=latest)](https://circuitpython.readthedocs.io/en/latest/docs/drivers.html) [![Gitter](https://badges.gitter.im/adafruit/circuitpython.svg)](https://gitter.im/adafruit/circuitpython?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Doc Status](https://readthedocs.org/projects/circuitpython/badge/?version=latest)](https://circuitpython.readthedocs.io/en/latest/docs/drivers.html) [![Discord](https://img.shields.io/discord/327254708534116352.svg)](https://adafru.it/discord)
 
 This repo bundles a bunch of useful CircuitPython libraries into an easy to
 download zip file. CircuitPython boards can ship with the contents of the zip to

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,2 @@
+See here for more info: https://github.com/adafruit/CircuitPython_Community_Bundle
+See VERSIONS.txt for version info.

--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,0 @@
-See here for more info: https://github.com/adafruit/CircuitPython_Community_Bundle
-See VERSIONS.txt for version info.


### PR DESCRIPTION
Replace the link to Gitter with a link to Discord in README.
Remove README.txt as we have README.md .