### PR TITLE
Add NeotrellisM4 extended library to the bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,3 +136,6 @@
 [submodule "libraries/drivers/74hc165"]
 	path = libraries/drivers/74hc165
 	url = https://github.com/WoolseyWorkshop/WoolseyWorkshop_CircuitPython_74HC165.git
+[submodule "libraries/drivers/trellism4_extended"]
+	path = libraries/drivers/trellism4_extended
+	url = https://github.com/arofarn/CircuitPython_TrellisM4_extended.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -32,6 +32,7 @@ Here is a listing of current CircuitPython Community Libraries. There are 46 lib
 * [at42qt-acorn-python](https://github.com/skerr92/at42qt-acorn-python.git)
 * [slight CircuitPython TLC5957](https://github.com/s-light/slight_CircuitPython_TLC5957.git)
 * [Woolsey Workshop CircuitPython 74HC165](https://github.com/WoolseyWorkshop/WoolseyWorkshop_CircuitPython_74HC165.git) ([PyPI](https://pypi.org/project/woolseyworkshop-circuitpython-74hc165/)) \([Docs](https://woolseyworkshop-circuitpython-74hc165.readthedocs.io/en/latest/))
+* [CircuitPython NeoTrellisM4 extended (with Neotrellis seesaw boards)] (https://github.com/arofarn/CircuitPython_TrellisM4_extended)
 
 ## Helpers:
 * [CIRCUITPYTHON ifttt](https://github.com/benevpi/CIRCUITPYTHON_ifttt.git) \([Docs](https://circuitpython-ifttt.readthedocs.io/))


### PR DESCRIPTION
Add a driver to use NeotrellisM4 board as part of multitrellis (tilled with neotrellis seesaw boards).