### PR TITLE
add CircuitPython_async helper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,3 +145,6 @@
 [submodule "libraries/drivers/bluepad32"]
 	path = libraries/drivers/bluepad32
 	url = https://github.com/ricardoquesada/bluepad32-circuitpython.git
+[submodule "libraries/helpers/asynccp"]
+	path = libraries/helpers/asynccp
+	url = https://github.com/WarriorOfWire/CircuitPython_async.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -1,7 +1,7 @@
 # CircuitPython Community Libraries
 ![Blinka Reading](https://raw.githubusercontent.com/adafruit/circuitpython-weekly-newsletter/gh-pages/assets/archives/22_1023blinka.png)
 
-Here is a listing of current CircuitPython Community Libraries. There are 48 libraries available.
+Here is a listing of current CircuitPython Community Libraries. There are 49 libraries available.
 
 ## Drivers:
 * [Adafruit Soundboard](https://github.com/mmabey/Adafruit_Soundboard.git)
@@ -54,3 +54,5 @@ Here is a listing of current CircuitPython Community Libraries. There are 48 lib
 * [PiperBlocklyLibrary](https://github.com/buildwithpiper/PiperBlocklyLibrary.git)
 * [circuitPython dotstar featherwing](https://github.com/dastels/circuitPython_dotstar_featherwing.git) \([Docs](https://circuitpython.readthedocs.io/projects/dotstar_featherwing/en/latest/))
 * [nonblocking timer](https://github.com/Angeleno-Tech/nonblocking_timer.git) \([Docs](https://circuitpython-nonblocking_timer.readthedocs.io/))
+* [CircuitPython_async](https://github.com/WarriorOfWire/CircuitPython_async.git)
+


### PR DESCRIPTION
This library adds an event loop for circuitpython async/await syntax.

resolves: https://github.com/WarriorOfWire/CircuitPython_async/issues/10