### PR TITLE
Add NAU7802 24-bit ADC driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -166,3 +166,6 @@
 [submodule "libraries/drivers/ticstepper"]
 	path = libraries/drivers/ticstepper
 	url = https://github.com/tekktrik/CircuitPython_TicStepper.git
+[submodule "libraries/drivers/nau7802"]
+	path = libraries/drivers/nau7802
+	url = https://github.com/CedarGroveStudios/nau7802

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -7,6 +7,7 @@ Here is a listing of current CircuitPython Community Libraries. There are 54 lib
 * [Adafruit Soundboard](https://github.com/mmabey/Adafruit_Soundboard.git)
 * [at42qt-acorn-python](https://github.com/skerr92/at42qt-acorn-python.git)
 * [Bluepad 32](https://github.com/ricardoquesada/bluepad32-circuitpython)
+* [CedarGrove CircuitPython NAU7802](https://github.com/CedarGroveStudios/nau7802.git) \ ([Docs](https://github.com/CedarGroveStudios/nau7802/blob/main/docs/pseudo%20readthedocs%20cedargrove_nau7802.pdf))
 * [CircuitPython AS3935](https://github.com/BiffoBear/CircuitPython_AS3935.git) \([Docs](https://circuitpython-as3935.readthedocs.io/))
 * [CircuitPython GC9A01](https://github.com/tylercrumpton/CircuitPython_GC9A01.git)
 * [CircuitPython HCSR04](https://github.com/mmabey/CircuitPython_HCSR04.git)


### PR DESCRIPTION
This is a driver for the NAU7802 24-bit ADC chip that is commonly used for reading standard 4-wire load cells via I2C such as the Adafruit PID#4540. This version was specifically written for a custom dual-channel FeatherWing, but will also work with the SparkFun Quiic Scale board using a single analog input ( https://www.sparkfun.com/products/15242).

Refer to the UI description document in the `doc`s folder, `pseudo readthedocs cedargrove_nau7802.pdf` and Clue-based tests in the `examples` folder.

This driver/board combination was tested with CircuitPython versions up to v7.2.4 on a variety of Adafruit boards including:

- M4 Feather
- PyPortal (regular, Titano, Pynt)
- Clue
- PyBadge/PyGamer
- RP2040 Feather

The repo for this submodule can be found here: https://github.com/CedarGroveStudios/nau7802

The custom FeatherWing can be ordered from OSH Park:

16-SOIC SMD version: https://oshpark.com/shared_projects/qFvEU3Bn
16-DIP THT version: https://oshpark.com/shared_projects/ZfryHYnc