### PR TITLE
Add NAU7802 24-bit ADC driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -166,3 +166,6 @@
 [submodule "libraries/drivers/ticstepper"]
 	path = libraries/drivers/ticstepper
 	url = https://github.com/tekktrik/CircuitPython_TicStepper.git
+[submodule "libraries/drivers/nau7802"]
+	path = libraries/drivers/nau7802
+	url = https://github.com/CedarGroveStudios/CircuitPython_NAU7802.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -11,6 +11,7 @@ Here is a listing of current CircuitPython Community Libraries. There are 54 lib
 * [CircuitPython GC9A01](https://github.com/tylercrumpton/CircuitPython_GC9A01.git)
 * [CircuitPython HCSR04](https://github.com/mmabey/CircuitPython_HCSR04.git)
 * [CircuitPython INA3221](https://github.com/barbudor/CircuitPython_INA3221.git) \([Docs](https://circuitpython-ina3221.readthedocs.io/en/latest/))
+* [CircuitPython_NAU7802](https://github.com/CedarGroveStudios/CircuitPython_NAU7802.git)
 * [CircuitPython SH1106](https://github.com/winneymj/CircuitPython_SH1106)
 * [CircuitPython TCA9555](https://github.com/lesamouraipourpre/Community_CircuitPython_TCA9555) \([PyPI](https://pypi.org/project/community-circuitpython-tca9555/)) \([Docs](http://community-circuitpython-tca9555.rtfd.io/))
 * [CircuitPython TMP75](https://github.com/barbudor/CircuitPython_TMP75.git) \([Docs](https://circuitpython-tmp75.readthedocs.io/en/latest/))


### PR DESCRIPTION
This is a driver for the NAU7802 24-bit ADC chip that is commonly used for reading standard 4-wire load cells via I2C such as the Adafruit PID#4540. This version was specifically written for a custom dual-channel FeatherWing, but will also work with the SparkFun Quiic Scale board using a single analog input ( https://www.sparkfun.com/products/15242).

This driver/board combination has been tested with CircuitPython versions up to v7.2.4 on a variety of Adafruit boards including:

- M4 Feather
- PyPortal (regular, Titano, Pynt)
- Clue
- PyBadge/PyGamer
- RP2040 Feather

The custom FeatherWing can be ordered from OSH Park:

16-SOIC SMD version: https://oshpark.com/shared_projects/qFvEU3Bn
16-DIP THT version: https://oshpark.com/shared_projects/ZfryHYnc