### PR TITLE
Add CircuitPython HX711 Driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -172,3 +172,6 @@
 [submodule "libraries/drivers/nau7802"]
 	path = libraries/drivers/nau7802
 	url = https://github.com/CedarGroveStudios/CircuitPython_NAU7802.git
+[submodule "libraries/drivers/hx711"]
+	path = libraries/drivers/hx711
+	url = https://github.com/fivesixzero/CircuitPython_HX711.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -10,6 +10,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython AS3935](https://github.com/BiffoBear/CircuitPython_AS3935.git) \([Docs](https://circuitpython-as3935.readthedocs.io/))
 * [CircuitPython GC9A01](https://github.com/tylercrumpton/CircuitPython_GC9A01.git)
 * [CircuitPython HCSR04](https://github.com/mmabey/CircuitPython_HCSR04.git)
+* [CircuitPython HX711](https://github.com/fivesixzero/CircuitPython_HX711) \([Docs](https://circuitpython-hx711.readthedocs.io/en/latest/))
 * [CircuitPython INA3221](https://github.com/barbudor/CircuitPython_INA3221.git) \([Docs](https://circuitpython-ina3221.readthedocs.io/en/latest/))
 * [CircuitPython_NAU7802](https://github.com/CedarGroveStudios/CircuitPython_NAU7802.git)
 * [CircuitPython SH1106](https://github.com/winneymj/CircuitPython_SH1106)


### PR DESCRIPTION
This is a driver for the ubiquitous HX711 load cell amp/ADC. It's been around for a long time and, although Adafruit doesn't have a breakout for it, it gets used pretty frequently in maker-focused kits and breakouts by a variety of vendors. This chip communicates via two-wire serial with the controller reading in bits one clock pulse at a time.

The driver's GPIO and PIO implementations were tested extensively using a Feather RP2040. While I haven't performed similar testing (yet) on other platforms, the GPIO bit-banging is as simple as it gets and the HX711 is unusually tolerant of clock deviations.

This is my first library so any feedback is welcome. :)