### PR TITLE
Add PaletteFader library to Community Bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -184,3 +184,6 @@
 [submodule "libraries/drivers/qwiicquadsolidstaterelay"]
 	path = libraries/drivers/qwiicquadsolidstaterelay
 	url = https://github.com/gbeland/CircuitPython_Sparkfun_QwiicQuadSolidStateRelay.git
+[submodule "libraries/helpers/palettefader"]
+	path = libraries/helpers/palettefader
+	url = https://github.com/CedarGroveStudios/CircuitPython_PaletteFader.git


### PR DESCRIPTION
PaletteFader is a CircuitPython color list and displayio palette brightness setter and normalizer tool. See [https://github.com/CedarGroveStudios/PaletteFader](url) for a detailed description, API, and use example.