### PR TITLE
Add CedarGrove CircuitPython RangeSlicer helper class

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -190,3 +190,6 @@
 [submodule "libraries/drivers/drv8830"]
 	path = libraries/drivers/drv8830
 	url = https://github.com/CedarGroveStudios/CircuitPython_DRV8830.git
+[submodule "libraries/helpers/rangeslicer"]
+	path = libraries/helpers/rangeslicer
+	url = https://github.com/CedarGroveStudios/CircuitPython_RangeSlicer.git


### PR DESCRIPTION
Range_Slicer is a general-purpose analog value converter that linearly scales the input then quantizes it into a collection of precise output slice values. The class detects input value changes and applies selectable hysteresis when slice edge thresholds are reached to eliminate dead-zone noise issues without filtering delays. Applications include converting rotary knob position to discrete ranges of MIDI values, analog signal noise processing, level detection, rotary switch emulation, and signal display.

For API and detailed functional description, see the original repo: https://github.com/CedarGroveStudios/Range_Slicer