### PR TITLE
Add CedarGrove PaletteFilter helper class

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -193,3 +193,6 @@
 [submodule "libraries/helpers/rangeslicer"]
 	path = libraries/helpers/rangeslicer
 	url = https://github.com/CedarGroveStudios/CircuitPython_RangeSlicer.git
+[submodule "libraries/helpers/palettefilter"]
+	path = libraries/helpers/palettefilter
+	url = https://github.com/Cedargrovestudios/circuitpython_paletteFilter.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -59,6 +59,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython I2C Button](https://github.com/gmparis/CircuitPython_I2C_Button) \([Docs](https://circuitpython-i2c-button.readthedocs.io/en/latest/))
 * [CircuitPython MorseCode](https://github.com/jposada202020/CircuitPython_MorseCode.git) ([PyPi](https://pypi.org/project/circuitpython-MorseCode)) \([Docs](https://circuitpython-morsecode.readthedocs.io/en/latest/))
 * [CircuitPython Palette Fader](https://github.com/CedarGroveStudios/CircuitPython_PaletteFader)
+* [CircuitPython Palette Filter](https://github.com/CedarGroveStudios/CircuitPython_PaletteFilter)
 * [CircuitPython Parse](https://github.com/jimbobbennett/CircuitPython_Parse) ([PyPi](https://pypi.org/project/circuitpython-parse)) \([Docs](https://circuitpython.readthedocs.io/projects/parse/en/latest/))
 * [CircuitPython_RangeSlicer](https://github.com/CedarGroveStudios/CircuitPython_RangeSlicer.git)
 * [CircuitPython_Schedule](https://pypi.org/project/circuitpython-schedule) ([PyPi](https://pypi.org/project/circuitpython-parse)) \([Docs](https://circuitpython-schedule.readthedocs.io/en/latest/))


### PR DESCRIPTION
Add CedarGrove CircuitPython PaletteFilter helper class

PaletteFilter is a CircuitPython helper class for replacing color index values in a `displayio.Palette` object. A target color along with a tolerance parameter determine the range of color values to be replaced. The class creates a new palette object with the changes. The replacement color value (or `None` for transparency) is substituted for the original palette entry and placed into the new palette object, `PaletteFilter.palette`.
