### PR TITLE
correct submodule and path camelcase for PaletteFader

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -257,6 +257,6 @@
 [submodule "libraries/drivers/laser_at"]
 	path = libraries/drivers/laser_at
 	url = https://github.com/furbrain/CircuitPython_laser_at.git
-[submodule "libraries/helpers/PaletteSlice"]
-	path = libraries/helpers/PaletteSlice
+[submodule "libraries/helpers/paletteslice"]
+	path = libraries/helpers/paletteslice
 	url = https://github.com/CedarGroveStudios/CircuitPython_PaletteSlice.git


### PR DESCRIPTION
To make it visible to circup, removed camelcase submodule and path designations for PaletteFader and replace with all lower-case.