### PR TITLE
Update PaletteSlice submodule definition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -257,7 +257,7 @@
 [submodule "libraries/drivers/laser_at"]
 	path = libraries/drivers/laser_at
 	url = https://github.com/furbrain/CircuitPython_laser_at.git
-[submodule "libraries/helpers/PaletteSlice"]
+[submodule "libraries/helpers/paletteslice"]
 	path = libraries/helpers/paletteslice
 	url = https://github.com/CedarGroveStudios/CircuitPython_PaletteSlice.git
 [submodule "libraries/drivers/jled-circuitpython"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -258,7 +258,7 @@
 	path = libraries/drivers/laser_at
 	url = https://github.com/furbrain/CircuitPython_laser_at.git
 [submodule "libraries/helpers/PaletteSlice"]
-	path = libraries/helpers/PaletteSlice
+	path = libraries/helpers/paletteslice
 	url = https://github.com/CedarGroveStudios/CircuitPython_PaletteSlice.git
 [submodule "libraries/drivers/jled-circuitpython"]
 	path = libraries/drivers/jled


### PR DESCRIPTION
Change the folder name from camelcase to lowercase to make the library visible to `circup`.