### PR TITLE
Add CedarGrove CircuitPython_AD5293 Digital Potentiometer driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -296,3 +296,6 @@
 [submodule "libraries/helpers/gauge"]
 	path = libraries/helpers/gauge
 	url = https://github.com/jposada202020/CircuitPython_gauge.git
+[submodule "libraries/drivers/ad5293"]
+	path = libraries/drivers/ad5293
+	url = https://github.com/CedarGroveStudios/CircuitPython_AD5293.git


### PR DESCRIPTION
The AD5293 Digital Potentiometer is a 10-bit, SPI, 100K-ohm device. The  potentiometer sports 1024 resistance steps. The digital logic power requires 2.7v to 5.5v. The potentiometer circuit operates with dual analog supply voltages from +/-9v to +/-16.5v. The pins act similarly to a passive resistive potentiometer, but require that voltages placed on any of the three pins not exceed the analog power supply voltages.

The CircuitPython driver supports a single SPI potentiometer device per instance. It will not work with daisy-chained devices.

The Cedar Grove AD5293 custom breakout board provides power and signal connections for SPI and the potentiometer chip. The AD5293 is also used in the AD9833-based Cedar Grove Precision VCO Eurorack module. The custom breakout board is available in the OSH Park public project collection.
