### PR TITLE
add CircuitPython_Cirque_Pinnacle driver library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -322,3 +322,6 @@
 [submodule "libraries/drivers/laser_egismos"]
 	path = libraries/drivers/laser_egismos
 	url = https://github.com/furbrain/CircuitPython_laser_egismos.git
+[submodule "libraries/drivers/cirque_pinnacle"]
+	path = libraries/drivers/cirque_pinnacle
+	url = https://github.com/2bndy5/CircuitPython_Cirque_Pinnacle.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -114,3 +114,4 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [NVM Helper](https://github.com/FoamyGuy/Foamyguy_CircuitPython_nvm_helper) Easy interface to store and retrieve objects persisted via NVM \([Docs](https://circuitpython-nvm-helper.readthedocs.io/))
 * [UUIDv4](https://github.com/DerBroader71/circuitpython_uuid4) This is a CircuitPython library to generate a UUID version 4
 * [PCF85063A](https://github.com/bablokb/circuitpython-pcf85063a) A CircuitPython library for the PCF85063A RTC
+* [Cirque Pinnacle](https://github.com/2bndy5/CircuitPython_Cirque_Pinnacle) A driver library to use circular trackpads (as seen in the Steam controller and HTC Vive VR controllers) empowered with Cirque's 1CA027 ASIC (surnamed "Pinnacle"). More information can be found in the [documentation](https://circuitpython-cirque-pinnacle.rtfd.io).

--- a/works_in_progress.md
+++ b/works_in_progress.md
@@ -22,4 +22,3 @@ help get the driver ready for the Bundle.
 * [https://github.com/maholli/CircuitPython_INA226](https://github.com/maholli/CircuitPython_INA226)
 * [https://github.com/maholli/CircuitPython_BQ25883](https://github.com/maholli/CircuitPython_BQ25883)
 * [https://github.com/spacecraft-design-lab-2019/CircuitPython_BMX160](https://github.com/spacecraft-design-lab-2019/CircuitPython_BMX160)
-* [https://github.com/2bndy5/CircuitPython_Cirque_Pinnacle](https://github.com/2bndy5/CircuitPython_Cirque_Pinnacle)


### PR DESCRIPTION
I finally got around to polishing the driver lib for the Cirque circular trackpads. Now that v1.0.0 is published, I removed the reference to the lib in the work_in_progress.md doc.