### PR TITLE
Add GC9D01 TFT LCD driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -382,3 +382,6 @@
 [submodule "libraries/helpers/caveble"]
 	path = libraries/helpers/caveble
 	url = https://github.com/furbrain/CircuitPython_CaveBLE.git
+[submodule "libraries/drivers/gc9d01"]
+	path = libraries/drivers/gc9d01
+	url = https://github.com/tylercrumpton/CircuitPython_GC9D01.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -19,6 +19,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython BMP581](https://github.com/jposada202020/CircuitPython_BMP581.git) Driver for the Bosch BMP581 Sensor ([PyPi](https://pypi.org/project/circuitpython-bmp581/)) \([Docs](https://circuitpython-bmp581.readthedocs.io/en/latest/))
 * [CircuitPython_DRV8830](https://github.com/CedarGroveStudios/CircuitPython_DRV8830.git) A driver for the DRV8830 DC motor controller.
 * [CircuitPython GC9A01](https://github.com/tylercrumpton/CircuitPython_GC9A01.git) Displayio driver for GC9A01 TFT LCD displays.
+* [CircuitPython GC9D01](https://github.com/tylercrumpton/CircuitPython_GC9D01.git) Displayio driver for GC9D01 TFT LCD displays.
 * [CircuitPython gpio_expander](https://github.com/gpongelli/CircuitPython_gpio_expander.git) I2C GPIO expander support for PCA9534, PCA9535, PCA9555, TCA9534, TCA9535 and TCA9555 chips. ([PyPi](https://pypi.org/project/circuitpython-gpio-expander/)) \([Docs](https://github.com/gpongelli/CircuitPython_gpio_expander/blob/main/README.rst))
 * [CircuitPython H3LIS200DL](https://github.com/jposada202020/CircuitPython_H3LIS200DL.git) Driver for the ST H3LIS200DL Accelerometer sensor ([PyPi](https://pypi.org/project/circuitpython-h3lis200dl/)) \([Docs](https://circuitpython-h3lis200dl.readthedocs.io/en/latest/))
 * [CircuitPython HCSR04](https://github.com/mmabey/CircuitPython_HCSR04.git) Library for The HC-SR04 for measuring distances using microcontrollers \([Docs](https://circuitpython-hcsr04.readthedocs.io/en/latest/))


### PR DESCRIPTION
Hiya! I've put together a displayio-compatible driver for GC9D01-based LCD screens. I think I've run through all of the appropriate steps, but please let me know if there are any changes that need to be made! Thanks!

![image](https://github.com/adafruit/CircuitPython_Community_Bundle/assets/1317406/3f567b99-0780-4d35-a73d-d34b6deaebb3)
