### PR TITLE
Add AT24MAC EEPROM driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -388,3 +388,6 @@
 [submodule "libraries/helpers/microosc"]
 	path = libraries/helpers/microosc
 	url = https://github.com/todbot/CircuitPython_MicroOSC.git
+[submodule "libraries/drivers/at24mac_eeprom"]
+	path = libraries/drivers/at24mac_eeprom
+	url = https://github.com/facts-engineering/CircuitPython_AT24MAC_EEPROM.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -5,6 +5,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 
 ## Drivers:
 * [Adafruit Soundboard](https://github.com/mmabey/Adafruit_Soundboard.git) An easy way to add sound to your maker project. \([Docs](https://adafruit-soundboard.readthedocs.io/en/latest/README.html))
+* [at24mac-eeprom](https://github.com/facts-engineering/CircuitPython_AT24MAC_EEPROM.git) I2C driver for the AT24MAC402 and AT24MAC602 devices.
 * [at42qt-acorn-python](https://github.com/skerr92/at42qt-acorn-python.git) Driver library for the AT42QT1070 Acorn.
 * [Bluepad 32](https://github.com/ricardoquesada/bluepad32-circuitpython) Enables gamepad support for CircuitPython.
 * [CircuitPython_AD5245](https://github.com/CedarGroveStudios/CircuitPython_AD5245.git) A driver for the AD5245 digital potentiometer. \([Docs](https://github.com/CedarGroveStudios/CircuitPython_AD5245/blob/main/media/pseudo_readthedocs_cedargrove_ad5245.pdf))


### PR DESCRIPTION
Hello, we've put together a driver for the AT24MAC402 and AT24MAC602 EEPROM devices. 

I think everything is put together correctly, let me know if any changes need to be made!

Thanks!