### PR TITLE
add ruhrohrotaryio for non-sequential pin rotaryio use on rp2040 et al #185 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -391,3 +391,6 @@
 [submodule "libraries/drivers/at24mac_eeprom"]
 	path = libraries/drivers/at24mac_eeprom
 	url = https://github.com/facts-engineering/CircuitPython_AT24MAC_EEPROM.git
+[submodule "libraries/drivers/ruhrohrotaryio"]
+	path = libraries/drivers/ruhrohrotaryio
+	url = git@github.com:todbot/CircuitPython_Community_Bundle.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -40,7 +40,6 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython RDA5807](https://github.com/tinkeringtech/CircuitPython_rda5807) rda5807m FM radio chip CircuitPython library \([Docs](https://circuitpython-rda5807m.readthedocs.io/en/latest/))
 * [CircuitPython RM3100](https://github.com/furbrain/CircuitPython_RM3100.git) Driver for the RM3100 magnetometer \([PyPI](https://circuitpython-rm3100.readthedocs.io/en/latest/)) \([Docs](https://circuitpython-rm3100.readthedocs.io/en/latest/))
 * [CircuitPython RuhRohRotaryIO](https://github.com/todbot/CircuitPython_RuhRohRotaryIO.git) CircuitPython library that pretents to be `rotaryio` for non-sequential pins ([PyPi](https://pypi.org/project/circuitpython-ruhrohrotaryio)) \([Docs](https://circuitpython-ruhrohrotaryio.readthedocs.io/en/latest/))
-
 * [CircuitPython SH1106](https://github.com/winneymj/CircuitPython_SH1106) CircuitPython driver for SH1106 OLED displays.
 * [CircuitPython Seeed XIAO nRF52840](https://github.com/furbrain/CircuitPython_seeed_xiao_nRF52840) Provides access to onboard sensors and battery charge management circuitry \([Docs](https://circuitpython-seeed-xiao-nrf52840.readthedocs.io/en/latest/))
 * [CircuitPython TCA9555](https://github.com/lesamouraipourpre/Community_CircuitPython_TCA9555) CircuitPython library for Texas Instruments TCA9555 Low-Voltage 16-Bit I2C and SMBus I/O Expander with Input / Output and Polarity Inversion. \([PyPI](https://pypi.org/project/community-circuitpython-tca9555/)) \([Docs](http://community-circuitpython-tca9555.rtfd.io/))

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -36,8 +36,11 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython PS2Controller](https://github.com/todbot/CircuitPython_PS2Controller.git) ([PyPi](https://pypi.org/project/circuitpython-ps2controller)) \([Docs](https://circuitpython-ps2controller.readthedocs.io/en/latest/)) CircuitPython library to read Sony PS2 game controllers
 * [CircuitPython_paj7620](https://github.com/deshipu/circuitpython-paj7620.git) A driver for the PAJ7620 gesture sensor.
 * [CircuitPython qmc5883l](https://github.com/jposada202020/CircuitPython_qmc5883l.git) Driver for the QMC5883l magnetometer ([PyPi](https://pypi.org/project/circuitpython-qmc5883l/) )\([Docs](https://readthedocs.org/projects/circuitpython-qmc5883l/en/latest/))
+
 * [CircuitPython RDA5807](https://github.com/tinkeringtech/CircuitPython_rda5807) rda5807m FM radio chip CircuitPython library \([Docs](https://circuitpython-rda5807m.readthedocs.io/en/latest/))
 * [CircuitPython RM3100](https://github.com/furbrain/CircuitPython_RM3100.git) Driver for the RM3100 magnetometer \([PyPI](https://circuitpython-rm3100.readthedocs.io/en/latest/)) \([Docs](https://circuitpython-rm3100.readthedocs.io/en/latest/))
+* [CircuitPython RuhRohRotaryIO](https://github.com/todbot/CircuitPython_RuhRohRotaryIO.git) CircuitPython library that pretents to be `rotaryio` for non-sequential pins ([PyPi](https://pypi.org/project/circuitpython-ruhrohrotaryio)) \([Docs](https://circuitpython-ruhrohrotaryio.readthedocs.io/en/latest/))
+
 * [CircuitPython SH1106](https://github.com/winneymj/CircuitPython_SH1106) CircuitPython driver for SH1106 OLED displays.
 * [CircuitPython Seeed XIAO nRF52840](https://github.com/furbrain/CircuitPython_seeed_xiao_nRF52840) Provides access to onboard sensors and battery charge management circuitry \([Docs](https://circuitpython-seeed-xiao-nrf52840.readthedocs.io/en/latest/))
 * [CircuitPython TCA9555](https://github.com/lesamouraipourpre/Community_CircuitPython_TCA9555) CircuitPython library for Texas Instruments TCA9555 Low-Voltage 16-Bit I2C and SMBus I/O Expander with Input / Output and Polarity Inversion. \([PyPI](https://pypi.org/project/community-circuitpython-tca9555/)) \([Docs](http://community-circuitpython-tca9555.rtfd.io/))


### PR DESCRIPTION
The rotaryio on at least RP2040 boards requires sequential GPIO pins which is confusing on, say, the QTPy RP2040 where pins seemingly next to each other like TX & SCL are not actually GPIO sequential. This little "fake rotaryio" driver acts like rotaryio but lets you any two pins.