### PR TITLE
Add setuptools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 circuitpython-build-tools
+setuptools


### PR DESCRIPTION
CI Python version is now 3.12. It needs `setuptools`:

From https://docs.python.org/3/whatsnew/3.12.html
> gh-95299: Do not pre-install setuptools in virtual environments created with venv. This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the activated virtual environment