### PR TITLE
Move the "biplane" library to the right spot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -346,7 +346,7 @@
 [submodule "libraries/drivers/bma400"]
 	path = libraries/drivers/bma400
 	url = https://github.com/jposada202020/CircuitPython_BMA400.git
-[submodule "libraries/biplane"]
+[submodule "libraries/helpers/biplane"]
 	path = libraries/helpers/biplane
 	url = https://github.com/Uberi/biplane.git
 [submodule "libraries/drivers/bmp581"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -347,7 +347,7 @@
 	path = libraries/drivers/bma400
 	url = https://github.com/jposada202020/CircuitPython_BMA400.git
 [submodule "libraries/biplane"]
-	path = libraries/biplane
+	path = libraries/helpers/biplane
 	url = https://github.com/Uberi/biplane.git
 [submodule "libraries/drivers/bmp581"]
 	path = libraries/drivers/bmp581


### PR DESCRIPTION
Because it was placed in the wrong location, it appears it was never actually available for installation via the bundle/circup. This location should be correct & allow installation.