### PR TITLE
Add new version of biplane and move it to the correct location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -346,9 +346,6 @@
 [submodule "libraries/drivers/bma400"]
 	path = libraries/drivers/bma400
 	url = https://github.com/jposada202020/CircuitPython_BMA400.git
-[submodule "libraries/biplane"]
-	path = libraries/biplane
-	url = https://github.com/Uberi/biplane.git
 [submodule "libraries/drivers/bmp581"]
 	path = libraries/drivers/bmp581
 	url = https://github.com/jposada202020/CircuitPython_BMP581.git
@@ -406,3 +403,6 @@
 [submodule "libraries/drivers/lilygo_tdeck"]
 	path = libraries/drivers/lilygo_tdeck
 	url = https://github.com/rgrizzell/CircuitPython_LILYGO_T-Deck.git
+[submodule "libraries/helpers/biplane"]
+	path = libraries/helpers/biplane
+	url = https://github.com/Uberi/biplane.git


### PR DESCRIPTION
An updated version of #197, but using the latest version of Biplane, which fixes the multiple top-level Python file issue described therein.