### PR TITLE
Fix axp2101

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -448,6 +448,3 @@
 [submodule "libraries/drivers/mcp48xx"]
 	path = libraries/drivers/mcp48xx
 	url = https://github.com/brushmate/CircuitPython_MCP48XX.git
-[submodule "libraries/driver/axp2101"]
-	path = libraries/driver/axp2101
-	url = https://github.com/CDarius/CircuitPython_AXP2101.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -448,3 +448,6 @@
 [submodule "libraries/drivers/mcp48xx"]
 	path = libraries/drivers/mcp48xx
 	url = https://github.com/brushmate/CircuitPython_MCP48XX.git
+[submodule "libraries/drivers/axp2101"]
+	path = libraries/drivers/axp2101
+	url = https://github.com/CDarius/CircuitPython_AXP2101.git


### PR DESCRIPTION
I just noticed that when I added the AXP2101 library to the bundle I mispelled the `drivers` folder and added the library on the `driver` folder