### PR TITLE
Add ST7565 / ST7567 displayio driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -451,3 +451,6 @@
 [submodule "libraries/driver/axp2101"]
 	path = libraries/driver/axp2101
 	url = https://github.com/CDarius/CircuitPython_AXP2101.git
+[submodule "libraries/drivers/displayio_st7565"]
+	path = libraries/drivers/displayio_st7565
+	url = https://github.com/mateusznowakdev/CircuitPython_DisplayIO_ST7565.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -19,6 +19,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython BMA423](https://github.com/jposada202020/CircuitPython_BMA423.git) Driver for the Bosch BMA423 Sensor ([PyPi](https://pypi.org/project/circuitpython-bma423/)) \([Docs](https://circuitpython-bma423.readthedocs.io/en/latest/))
 * [CircuitPython BMI160](https://github.com/jposada202020/CircuitPython_BMI160.git) Driver for the Bosch BMI160 Sensor ([PyPi](https://pypi.org/project/circuitpython-bmi160/)) \([Docs](https://circuitpython-bmi160.readthedocs.io/en/latest/))
 * [CircuitPython BMP581](https://github.com/jposada202020/CircuitPython_BMP581.git) Driver for the Bosch BMP581 Sensor ([PyPi](https://pypi.org/project/circuitpython-bmp581/)) \([Docs](https://circuitpython-bmp581.readthedocs.io/en/latest/))
+* [CircuitPython DisplayIO ST7565](https://github.com/mateusznowakdev/CircuitPython_DisplayIO_ST7565.git) CircuitPython displayio driver for ST7565 and ST7567 displays \([Docs](https://circuitpython-displayio-st7565.readthedocs.io/en/latest/))
 * [CircuitPython_DRV8830](https://github.com/CedarGroveStudios/CircuitPython_DRV8830.git) A driver for the DRV8830 DC motor controller.
 * [CircuitPython GC9A01](https://github.com/tylercrumpton/CircuitPython_GC9A01.git) Displayio driver for GC9A01 TFT LCD displays.
 * [CircuitPython GC9D01](https://github.com/tylercrumpton/CircuitPython_GC9D01.git) Displayio driver for GC9D01 TFT LCD displays.


### PR DESCRIPTION
This PR adds the ST7565 displayio driver, based on the framebuf implementation found in the main Adafruit bundle. The init sequence is the same.

I've tested it with the ST7567 128x64 display I have, and it works just fine (except for the initial bias value but I've added a setter for this as well). Since ST7565 and ST7567 are very similar (if not the same), this driver should be compatible with both.