### PR TITLE
dotstar_featherwing: Move to a different fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/mmabey/Adafruit_Soundboard.git
 [submodule "libraries/helpers/dotstar_featherwing"]
 	path = libraries/helpers/dotstar_featherwing
-	url = https://github.com/dastels/circuitPython_dotstar_featherwing.git
+	url = https://github.com/jepler/circuitPython_dotstar_featherwing.git
 [submodule "libraries/helpers/nonblocking_timer"]
 	path = libraries/helpers/nonblocking_timer
 	url = https://github.com/Angeleno-Tech/nonblocking_timer.git


### PR DESCRIPTION
The original maintainer has not responded to a needed PR over several months, blocking https://github.com/adafruit/circuitpython-build-tools/pull/111

At this point, I think the viable alternatives are to move to a different fork or to remove the library. I have no way of knowing how widely the library is used; nothing in Learn uses it. I don't really want to maintain the library, I just want to omve forward that circuitpython-build-tools PR.