### PR TITLE
Use skip_failed flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,4 @@ gawk -F '\n' '{ match($1, /(drivers|helpers)\/(.+)\/(.+)\:/, arr) ; if (length(a
 gawk '{ trimmed = substr($0, 1, length($0) - 2) ; print "\"" trimmed "\"" }'
 )
 
-circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 2 --package_folder_prefix "$P"
+circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 2 --package_folder_prefix "$P" --skip_failed


### PR DESCRIPTION
This depends upon [#121](https://github.com/adafruit/circuitpython-build-tools/pull/121) The actions here can't pass until that PR is merged I think, they'll need to be re-run afterward.

This makes the build script here utilize the new flag added in that PR so that the actions task will not fail if specific libraries within the community bundle fail to build.