### PR TITLE
Add support for NXP PCA9955b 16-Channel I2C-Bus LED Driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -445,3 +445,6 @@
 [submodule "libraries/helpers/pio_i2s"]
 	path = libraries/helpers/pio_i2s
 	url = https://github.com/relic-se/CircuitPython_PIO_I2S.git
+[submodule "libraries/drivers/pca9955b"]
+	path = libraries/drivers/pca9955b
+	url = https://github.com/noelanderson/CircuitPython_PCA9955B.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -36,6 +36,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython PS2Controller](https://github.com/todbot/CircuitPython_PS2Controller.git) ([PyPi](https://pypi.org/project/circuitpython-ps2controller)) \([Docs](https://circuitpython-ps2controller.readthedocs.io/en/latest/)) CircuitPython library to read Sony PS2 game controllers
 * [CircuitPython_paj7620](https://github.com/deshipu/circuitpython-paj7620.git) A driver for the PAJ7620 gesture sensor.
 * [CircuitPython PCA9674](https://github.com/XENONFFM/CircuitPython_PCA9674.git) Driver for the NXP PCA9674(A) 8 channel I2C I/O expander ([PyPi](https://pypi.org/project/circuitpython-pca9674))
+* [CircuitPython PCA9955b](https://github.com/noelanderson/CircuitPython_PCA9955B.git) Driver for the NXP PCA9955b 16-Channel I2C-Bus Constant-Current LED Driver ([Docs](https://circuitpython-pca9955b.readthedocs.io/en/latest/))
 * [CircuitPython qmi8658c](https://github.com/jins-tkomoda/CircuitPython_QMI8658C.git) Driver for the QMI8658C inertial measurement unit 
 ([Docs](https://circuitpython-qmi8658c.readthedocs.io/en/latest/))
 * [CircuitPython Raspberry PI Build HAT](https://github.com/CDarius/CircuitPython_RaspberryPI_BuildHAT.git) Driver for Raspberry PI Build HAT \([Docs](https://circuitpython-raspberrypi-buildhat.readthedocs.io/en/latest/))


### PR DESCRIPTION
This is a driver library that adds support for the NXP 16-Channel I²C-Bus Constant-Current LED Driver
https://www.nxp.com/products/power-management/lighting-driver-and-controller-ics/led-drivers/16-channel-fm-plus-ic-bus-57-ma-20-v-constant-current-led-driver:PCA9955BTW