### PR TITLE
move dotstart_featherwing to its new repo URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/mmabey/Adafruit_Soundboard.git
 [submodule "libraries/helpers/dotstar_featherwing"]
 	path = libraries/helpers/dotstar_featherwing
-	url = https://github.com/jepler/circuitPython_dotstar_featherwing.git
+	url = https://github.com/circuitpython/circuitPython_dotstar_featherwing.git
 [submodule "libraries/helpers/nonblocking_timer"]
 	path = libraries/helpers/nonblocking_timer
 	url = https://github.com/Angeleno-Tech/nonblocking_timer.git


### PR DESCRIPTION
This repo now lives in the CircuitPython org. https://github.com/circuitpython/circuitPython_dotstar_featherwing

Updating here should allow the bundle to successfully update its submodules in order to complete the rest of the actions that come afterward