### PR TITLE
remove i2c_button

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,9 +139,6 @@
 [submodule "libraries/drivers/trellism4_extended"]
 	path = libraries/drivers/trellism4_extended
 	url = https://github.com/arofarn/CircuitPython_TrellisM4_extended.git
-[submodule "libraries/drivers/i2c_button"]
-	path = libraries/drivers/i2c_button
-	url = https://github.com/gmparis/CircuitPython_I2C_Button.git
 [submodule "libraries/drivers/bluepad32"]
 	path = libraries/drivers/bluepad32
 	url = https://github.com/ricardoquesada/bluepad32-circuitpython.git


### PR DESCRIPTION
This repo has been deleted.

I believe this is the root cause of the update_bundles action failing here: https://github.com/adafruit/circuitpython/actions/runs/24328003133/job/71027320835

I was able to add some additional logging to the adabot CLI tool and run it locally to capture more of the outout than actions does and found this: 

```
Cloning into '/home/timc/repos/circuitpython/adabot/.bundles/CircuitPython_Community_Bundle/libraries/drivers/i2c_button'...
remote: Repository not found.
fatal: repository 'https://github.com/gmparis/CircuitPython_I2C_Button.git/' not found
fatal: clone of 'https://github.com/gmparis/CircuitPython_I2C_Button.git' into submodule path '/home/timc/repos/circuitpython/adabot/.bundles/CircuitPython_Community_Bundle/libraries/drivers/i2c_button' failed
Failed to clone 'libraries/drivers/i2c_button' a second time, aborting
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/timc/repos/circuitpython/adabot/adabot/circuitpython_bundle.py", line 630, in <module>
    fetch_bundle(cp_bundle, bundle_dir)
  File "/home/timc/repos/circuitpython/adabot/adabot/circuitpython_bundle.py", line 64, in fetch_bundle
    git.submodule("update", _out=sys.stdout, _err=sys.stderr)
  File "/home/timc/repos/circuitpython/adabot/.adabot_venv/lib/python3.12/site-packages/sh.py", line 1427, in __call__
    return RunningCommand(cmd, call_args, stdin, stdout, stderr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/timc/repos/circuitpython/adabot/.adabot_venv/lib/python3.12/site-packages/sh.py", line 774, in __init__
    self.wait()
  File "/home/timc/repos/circuitpython/adabot/.adabot_venv/lib/python3.12/site-packages/sh.py", line 792, in wait
    self.handle_command_exit_code(exit_code)
  File "/home/timc/repos/circuitpython/adabot/.adabot_venv/lib/python3.12/site-packages/sh.py", line 815, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1: 

  RAN: /usr/bin/git submodule update

  STDOUT:


  STDERR:
```