### PR TITLE
Add circuitpython-sevenseg library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -526,3 +526,6 @@
 [submodule "libraries/helpers/bambulabs"]
 	path = libraries/helpers/bambulabs
 	url = https://github.com/prcutler/CircuitPython_bambulabs.git
+[submodule "libraries/sevenseg"]
+	path = libraries/sevenseg
+	url = https://github.com/kritishmohapatra/circuitpython-sevenseg.git


### PR DESCRIPTION
## New Library: circuitpython-sevenseg

A lightweight CircuitPython library for controlling single-digit 
7-segment displays with full character support.

- Supports digits 0-9, A-Z, a-z, symbols
- Common cathode and common anode support
- Tested on Raspberry Pi Pico 2W

PyPI: https://pypi.org/project/circuitpython-sevenseg/