### PR TITLE
Add CircuitPython_DS1302 Real Time Clock library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -529,3 +529,6 @@
 [submodule "libraries/sevenseg"]
 	path = libraries/helpers/sevenseg
 	url = https://github.com/kritishmohapatra/circuitpython-sevenseg.git
+[submodule "libraries/drivers/ds1302"]
+	path = libraries/drivers/ds1302
+	url = https://github.com/Elfking29/CircuitPython_DS1302.git

--- a/circuitpython_community_library_list.md
+++ b/circuitpython_community_library_list.md
@@ -19,6 +19,7 @@ Here is a listing of current CircuitPython Community Libraries. These libraries 
 * [CircuitPython BMA220](https://github.com/jposada202020/CircuitPython_BMA220.git) Driver for the Bosch BMA220 Sensor ([PyPi](https://pypi.org/project/circuitpython-bma220/)) ([Docs](https://circuitpython-bma220.readthedocs.io/en/latest/))
 * [CircuitPython DisplayIO ST7565](https://github.com/mateusznowakdev/CircuitPython_DisplayIO_ST7565.git) CircuitPython displayio driver for ST7565 and ST7567 displays ([Docs](https://circuitpython-displayio-st7565.readthedocs.io/en/latest/))
 * [CircuitPython_DRV8830](https://github.com/CedarGroveStudios/CircuitPython_DRV8830.git) A driver for the DRV8830 DC motor controller.
+* [CircuitPython_DS1302](https://github.com/Elfking29/CircuitPython_DS1302.git) Driver for the Maxim Integrated / Analog Devices DS1302 Real Time Clock. ([PyPi](https://pypi.org/project/circuitpython-ds1302/)) ([Docs](https://circuitpython-ds1302.readthedocs.io/en/latest/))
 * [CircuitPython FS3000](https://github.com/noelanderson/CircuitPython_FS3000.git) Driver for the Renesas FS3000 Air Velocity Sensor Module ([Docs](https://circuitpython-fs3000.readthedocs.io/en/latest/))
 * [CircuitPython GC9A01](https://github.com/tylercrumpton/CircuitPython_GC9A01.git) Displayio driver for GC9A01 TFT LCD displays.
 * [CircuitPython GC9D01](https://github.com/tylercrumpton/CircuitPython_GC9D01.git) Displayio driver for GC9D01 TFT LCD displays.


### PR DESCRIPTION
## New Library: CircuitPython_DS1302

A CircuitPython driver for the DS1302 Real Time Clock

GitHub: https://github.com/Elfking29/CircuitPython_DS1302
Documentation: https://circuitpython-ds1302.readthedocs.io/en/latest/
PyPi: https://pypi.org/project/circuitpython-ds1302/
Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ds1302.pdf

Features:
- Date and time support
- User RAM access
- Trickle charger configuration


I've never submitted a library to the Bundle before, so please let me know if I've missed anything. Thanks!