### PR TITLE
Added CircuitPython_KineticRGB submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -532,3 +532,6 @@
 [submodule "libraries/drivers/ds1302"]
 	path = libraries/drivers/ds1302
 	url = https://github.com/Elfking29/CircuitPython_DS1302.git
+[submodule "libraries/drivers/KineticRGB"]
+	path = libraries/drivers/KineticRGB
+	url = https://github.com/Kinetic-Technologies-Inc/CircuitPython_KineticRGB.git


### PR DESCRIPTION
# CircuitPython_KineticRGB Submodule

## Summary
Adds the KineticRGB CircuitPython library submodule to the Community Bundle.

## Changes
- Added `CircuitPython_KineticRGB` as a submodule under `libraries/driver/`

## Formatting
- Passes pre-commit (adafruit cookiecutter)
- all code tested working on QTPY RP2040
- Sphinx documentation shows no errors